### PR TITLE
added option to show power and consumption bar

### DIFF
--- a/automotive/src/main/java/com/ixam97/carStatsViewer/activities/MainActivity.kt
+++ b/automotive/src/main/java/com/ixam97/carStatsViewer/activities/MainActivity.kt
@@ -234,27 +234,29 @@ class MainActivity : Activity() {
     }
 
     private fun updateGages() {
-        main_power_gage.setValue(DataHolder.currentPowerSmooth / 1000000)
-        var consumptionValue: Float? = null
+        if(AppPreferences.gagesOn){
+            main_power_gage.setValue(DataHolder.currentPowerSmooth / 1000000)
+            var consumptionValue: Float? = null
 
-        if (AppPreferences.consumptionUnit) {
-            main_consumption_gage.gageUnit = "Wh/km"
-            main_consumption_gage.minValue = -300f
-            main_consumption_gage.maxValue = 600f
-            if (DataHolder.currentSpeed * 3.6 > 3) {
-                main_consumption_gage.setValue(((DataHolder.currentPowerSmooth / 1000) / (DataHolder.currentSpeedSmooth * 3.6)).toInt())
-            } else {
-                main_consumption_gage.setValue(consumptionValue)
-            }
+            if (AppPreferences.consumptionUnit) {
+                main_consumption_gage.gageUnit = "Wh/km"
+                main_consumption_gage.minValue = -300f
+                main_consumption_gage.maxValue = 600f
+                if (DataHolder.currentSpeed * 3.6 > 3) {
+                    main_consumption_gage.setValue(((DataHolder.currentPowerSmooth / 1000) / (DataHolder.currentSpeedSmooth * 3.6)).toInt())
+                } else {
+                    main_consumption_gage.setValue(consumptionValue)
+                }
 
-        } else {
-            main_consumption_gage.gageUnit = "kWh/100km"
-            main_consumption_gage.minValue = -30f
-            main_consumption_gage.maxValue = 60f
-            if (DataHolder.currentSpeed * 3.6 > 3) {
-                main_consumption_gage.setValue(((DataHolder.currentPowerSmooth / 1000) / (DataHolder.currentSpeedSmooth * 3.6f))/10)
             } else {
-                main_consumption_gage.setValue(consumptionValue)
+                main_consumption_gage.gageUnit = "kWh/100km"
+                main_consumption_gage.minValue = -30f
+                main_consumption_gage.maxValue = 60f
+                if (DataHolder.currentSpeed * 3.6 > 3) {
+                    main_consumption_gage.setValue(((DataHolder.currentPowerSmooth / 1000) / (DataHolder.currentSpeedSmooth * 3.6f))/10)
+                } else {
+                    main_consumption_gage.setValue(consumptionValue)
+                }
             }
         }
     }

--- a/automotive/src/main/java/com/ixam97/carStatsViewer/activities/SettingsActivity.kt
+++ b/automotive/src/main/java/com/ixam97/carStatsViewer/activities/SettingsActivity.kt
@@ -29,6 +29,7 @@ class SettingsActivity : Activity() {
         settings_switch_notifications.isChecked = AppPreferences.notifications
         settings_switch_consumption_unit.isChecked = AppPreferences.consumptionUnit
         settings_switch_experimental_layout.isChecked = AppPreferences.experimentalLayout
+        settings_switch_gagesOn.isChecked = AppPreferences.gagesOn
         // settings_switch_consumption_plot.isChecked = AppPreferences.consumptionPlot
 
         settings_version_text.text = String.format("Car Stats Viewer Version %s (Build %d)",
@@ -86,6 +87,13 @@ class SettingsActivity : Activity() {
                 .apply()
             AppPreferences.experimentalLayout = settings_switch_experimental_layout.isChecked
         }
+        settings_switch_gagesOn.setOnClickListener {
+            sharedPref.edit()
+                .putBoolean(getString(R.string.preferences_gagesOn_key), settings_switch_gagesOn.isChecked)
+                .apply()
+            AppPreferences.gagesOn = settings_switch_gagesOn.isChecked
+        }
+
 /*
         settings_switch_consumption_plot.setOnClickListener {
             sharedPref.edit()

--- a/automotive/src/main/java/com/ixam97/carStatsViewer/objects/AppPreferences.kt
+++ b/automotive/src/main/java/com/ixam97/carStatsViewer/objects/AppPreferences.kt
@@ -5,6 +5,7 @@ object AppPreferences {
     var notifications = false
     var consumptionUnit = false
     var experimentalLayout = false
+    var gagesOn = true
     var deepLog = false
     var plotSpeed = false
     var plotDistance = 1

--- a/automotive/src/main/java/com/ixam97/carStatsViewer/views/GageView.kt
+++ b/automotive/src/main/java/com/ixam97/carStatsViewer/views/GageView.kt
@@ -5,6 +5,7 @@ import android.graphics.*
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.View
+import com.ixam97.carStatsViewer.objects.AppPreferences
 import java.text.DecimalFormat
 import java.util.*
 import kotlin.math.min
@@ -90,7 +91,8 @@ class GageView(context: Context, attrs: AttributeSet) : View(context, attrs) {
 
     private val xTextMargin = dpToPx(15f)
     private val yTextMargin = dpToPx(10f)
-    private val gageWidth = dpToPx(60f)
+    private val gageWidth = if(AppPreferences.gagesOn){
+        dpToPx(60f)} else { dpToPx(0f)}
 
     private val nameYPos = namePaint.textSize * 0.76f
     private val valueYPos = nameYPos + valuePaint.textSize * 0.9f

--- a/automotive/src/main/res/layout/activity_main.xml
+++ b/automotive/src/main/res/layout/activity_main.xml
@@ -14,16 +14,16 @@
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
             android:layout_marginVertical="15dp"
-            android:src="@drawable/ic_launcher_foreground"/>
+            android:layout_marginStart="20dp"
+            android:src="@drawable/ic_launcher_foreground" />
 
         <TextView
             android:id="@+id/main_title"
             style="@style/title_text_style"
-            android:text="@string/app_name"/>
+            android:text="@string/app_name" />
 
-        <View style="@style/filler"/>
+        <View style="@style/filler" />
 
         <ImageButton
             android:id="@+id/main_button_reset"
@@ -32,7 +32,7 @@
             android:layout_marginVertical="15dp"
             android:layout_marginEnd="10dp"
             android:background="@android:color/transparent"
-            android:src="@drawable/ic_reset"/>
+            android:src="@drawable/ic_reset" />
 
         <ImageButton
             android:id="@+id/main_button_settings"
@@ -41,35 +41,35 @@
             android:layout_marginVertical="15dp"
             android:layout_marginEnd="15dp"
             android:background="@android:color/transparent"
-            android:src="@drawable/ic_settings"/>
+            android:src="@drawable/ic_settings" />
 
     </LinearLayout>
 
     <View
         android:layout_width="match_parent"
         android:layout_height="2dp"
-        android:background="?android:attr/colorControlActivated"/>
+        android:background="?android:attr/colorControlActivated" />
 
     <LinearLayout
         android:id="@+id/gage_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:weightSum="14"
-        android:visibility="gone">
+        android:visibility="gone"
+        android:weightSum="14">
 
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_weight="8">
+            android:layout_weight="8"
+            android:orientation="vertical">
 
             <com.ixam97.carStatsViewer.views.GageView
                 android:id="@+id/main_power_gage"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_marginHorizontal="20dp"/>
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginTop="20dp" />
 
             <!--<com.ixam97.carStatsViewer.views.GageView
                 android:id="@+id/main_speed_gage"
@@ -82,21 +82,21 @@
                 android:id="@+id/main_consumption_gage"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_margin="20dp"/>
+                android:layout_margin="20dp" />
 
         </LinearLayout>
 
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:orientation="horizontal"
-            android:layout_weight="6">
+            android:layout_weight="6"
+            android:orientation="horizontal">
 
             <View
                 android:layout_width="2dp"
                 android:layout_height="match_parent"
-                android:background="?android:attr/listDivider"
-                android:layout_margin="15dp"/>
+                android:layout_margin="15dp"
+                android:background="?android:attr/listDivider" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -108,10 +108,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="35sp"
                     android:drawableStart="@drawable/ic_distance"
-                    />
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="35sp" />
 
 
                 <TextView
@@ -119,31 +118,28 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="5dp"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="35sp"
                     android:drawableStart="@drawable/ic_power"
-                    />
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="35sp" />
 
                 <TextView
                     android:id="@+id/main_gage_avg_consumption_text_view"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="5dp"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="35sp"
                     android:drawableStart="@drawable/ic_avg_consumption"
-                    />
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="35sp" />
 
                 <TextView
                     android:id="@+id/main_gage_time_text_view"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="5dp"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="35sp"
-                    android:text="  00:00:00"
                     android:drawableStart="@drawable/ic_time"
-                    />
+                    android:text="  00:00:00"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="35sp" />
 
                 <TextView
                     android:id="@+id/main_gage_remaining_range_text_view"
@@ -151,11 +147,10 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="5dp"
                     android:layout_marginBottom="10dp"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="35sp"
-                    android:text="  --- km"
                     android:drawableStart="@drawable/ic_remaining_range"
-                    />
+                    android:text="  --- km"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="35sp" />
 
             </LinearLayout>
         </LinearLayout>
@@ -313,22 +308,22 @@
 
     <LinearLayout
         android:id="@+id/main_consumption_plot_container"
-        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
         <View
             android:layout_width="match_parent"
             android:layout_height="2dp"
             android:layout_weight="0"
-            android:background="?android:attr/listDivider"/>
+            android:background="?android:attr/listDivider" />
 
         <com.ixam97.carStatsViewer.views.PlotView
+            android:id="@+id/main_consumption_plot"
             android:layout_width="match_parent"
             android:layout_height="fill_parent"
-            android:layout_weight="1"
             android:layout_margin="0dp"
-            android:id="@+id/main_consumption_plot"/>
+            android:layout_weight="1" />
 
         <LinearLayout
             android:layout_width="wrap_content"
@@ -344,66 +339,69 @@
                 android:layout_marginBottom="5dp"
                 android:layout_weight="0"
                 android:orientation="horizontal">
+
                 <RadioButton
                     android:id="@+id/main_radio_10"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="10dp"
-                    android:textSize="35sp"
-                    android:text="10 km"/>
+                    android:text="10 km"
+                    android:textSize="35sp" />
+
                 <RadioButton
                     android:id="@+id/main_radio_25"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="10dp"
-                    android:textSize="35sp"
-                    android:text="25 km"/>
+                    android:text="25 km"
+                    android:textSize="35sp" />
+
                 <RadioButton
                     android:id="@+id/main_radio_50"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="10dp"
-                    android:textSize="35sp"
-                    android:text="Trip"/>
+                    android:text="Trip"
+                    android:textSize="35sp" />
             </RadioGroup>
 
             <View
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:layout_weight="1"/>
+                android:layout_weight="1" />
 
             <CheckBox
                 android:id="@+id/main_checkbox_speed"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/main_checkbox_speed"
-                android:textSize="35sp"
+                android:layout_marginHorizontal="15dp"
                 android:layout_marginTop="0dp"
                 android:layout_marginBottom="5dp"
-                android:layout_marginHorizontal="15dp"/>
+                android:text="@string/main_checkbox_speed"
+                android:textSize="35sp" />
         </LinearLayout>
 
     </LinearLayout>
 
     <LinearLayout
         android:id="@+id/main_charge_plot_container"
-        android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:orientation="vertical"
         android:visibility="visible">
 
         <View
             android:layout_width="match_parent"
             android:layout_height="2dp"
             android:layout_weight="0"
-            android:background="?android:attr/listDivider"/>
+            android:background="?android:attr/listDivider" />
 
         <com.ixam97.carStatsViewer.views.PlotView
+            android:id="@+id/main_charge_plot"
             android:layout_width="match_parent"
             android:layout_height="fill_parent"
-            android:layout_weight="1"
             android:layout_margin="0dp"
-            android:id="@+id/main_charge_plot"/>
+            android:layout_weight="1" />
 
     </LinearLayout>
 

--- a/automotive/src/main/res/layout/activity_settings.xml
+++ b/automotive/src/main/res/layout/activity_settings.xml
@@ -74,6 +74,13 @@
             android:background="?android:attr/listDivider"/>
 
         <Switch
+            android:id="@+id/settings_switch_gagesOn"
+            style="@style/menu_standard_switch_style"
+            android:layout_width="match_parent"
+            android:layout_height="101dp"
+            android:text="@string/settings_gagesOn" />
+
+        <Switch
             android:id="@+id/settings_switch_debug"
             style="@style/menu_standard_switch_style"
             android:text="@string/settings_debug"

--- a/automotive/src/main/res/values-de/strings.xml
+++ b/automotive/src/main/res/values-de/strings.xml
@@ -27,6 +27,7 @@
     <string name="settings_consumption_unit">Wh/km als Verbrauchseinheit</string>
     <string name="settings_debug">Debug-Informationen</string>
     <string name="settings_experimental_layout">Zeige experimentelles Layout</string>
+    <string name="settings_gagesOn">Zeige Power- und Verbrauchsbalken</string>
     <string name="settings_consumption_plot">Einstellungen für Verbrauchsanzeige</string>
     <string name="settings_charge_plot">Einstellungen für Ladekurve</string>
 

--- a/automotive/src/main/res/values/strings.xml
+++ b/automotive/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="preferences_plot_distance_key" translatable="false">preferences_plot_distance</string>
     <string name="preferences_plot_speed_key" translatable="false">preferences_plot_speed</string>
     <string name="preferences_experimental_layout_key" translatable="false">preferences_experimental_layout</string>
+    <string name="preferences_gagesOn_key" translatable="false">preferences_gagesOn</string>
 
     <!-- MainActivity -->
     <string name="main_port_connected">Charge port connected:</string>
@@ -40,6 +41,7 @@
     <string name="settings_consumption_unit">Wh/km as consumption unit</string>
     <string name="settings_debug">Debug information</string>
     <string name="settings_experimental_layout">Show experimental Layout</string>
+    <string name="settings_gagesOn">Show power and consump. bars</string>
     <string name="settings_consumption_plot">Consumption plot settings</string>
     <string name="settings_charge_plot">Charge plot settings</string>
 


### PR DESCRIPTION
quick solution to reduce the bars to 0dp width and do not trigger any update.

Due to commits in the meantime, cherrypicking might be necessary.