### PR TITLE
PoC: HTTP Live Data

### DIFF
--- a/automotive/src/main/java/com/ixam97/carStatsViewer/activities/MainActivity.kt
+++ b/automotive/src/main/java/com/ixam97/carStatsViewer/activities/MainActivity.kt
@@ -76,6 +76,7 @@ class MainActivity : Activity() {
                 getString(R.string.ui_update_plot_broadcast) -> updatePlots()
                 getString(R.string.ui_update_gages_broadcast) -> updateGages()
                 getString(R.string.abrp_connection_broadcast) -> updateAbrpStatus(intent.getIntExtra("status", 0))
+                getString(R.string.http_connection_broadcast) -> updateHTTStatus(intent.getIntExtra("status", 0))
             }
         }
     }
@@ -353,6 +354,20 @@ class MainActivity : Activity() {
     }
 
     private fun updateAbrpStatus(status: Int) {
+        when (status) {
+            1 -> {
+                main_icon_abrp_status.setColorFilter(Color.parseColor("#2595FF"))
+                main_icon_abrp_status.visibility = View.VISIBLE
+            }
+            2 -> {
+                main_icon_abrp_status.setColorFilter(getColor(R.color.bad_red))
+                main_icon_abrp_status.visibility = View.VISIBLE
+            }
+            else -> main_icon_abrp_status.visibility = View.GONE
+        }
+    }
+
+    private fun updateHTTStatus(status: Int) {
         when (status) {
             1 -> {
                 main_icon_abrp_status.setColorFilter(Color.parseColor("#2595FF"))

--- a/automotive/src/main/java/com/ixam97/carStatsViewer/activities/SettingsActivity.kt
+++ b/automotive/src/main/java/com/ixam97/carStatsViewer/activities/SettingsActivity.kt
@@ -34,6 +34,7 @@ import com.ixam97.carStatsViewer.dataManager.DataManagers
 import com.ixam97.carStatsViewer.enums.DistanceUnitEnum
 import com.ixam97.carStatsViewer.plot.objects.PlotGlobalConfiguration
 import com.ixam97.carStatsViewer.views.PlotView
+import java.net.URL
 import kotlin.system.exitProcess
 
 class SettingsActivity : Activity() {
@@ -201,6 +202,26 @@ class SettingsActivity : Activity() {
                 }
                 setTitle("ABRP Generic Token")
                 setMessage("Enter ABRP Generic Token to transmit live data to the ABRP servers.")
+                setCancelable(true)
+                create()
+            }
+            tokenDialog.show()
+        }
+
+        settings_http_data.setOnClickListener {
+            val tokenDialog = AlertDialog.Builder(this@SettingsActivity).apply {
+                val layout = LayoutInflater.from(this@SettingsActivity).inflate(R.layout.dialog_http_data, null)
+                val liveDataURL = layout.findViewById<EditText>(R.id.http_live_data_url)
+
+                liveDataURL.setText(appPreferences.httpLiveDataURL)
+
+                setView(layout)
+
+                setPositiveButton("OK") { dialog, _ ->
+                    appPreferences.httpLiveDataURL = liveDataURL.text.toString()
+                }
+                setTitle("Live Data URL")
+                setMessage("Enter URL to transmit live data to the specified location.")
                 setCancelable(true)
                 create()
             }

--- a/automotive/src/main/java/com/ixam97/carStatsViewer/appPreferences/AppPreferences.kt
+++ b/automotive/src/main/java/com/ixam97/carStatsViewer/appPreferences/AppPreferences.kt
@@ -8,6 +8,7 @@ import com.ixam97.carStatsViewer.R
 import com.ixam97.carStatsViewer.enums.DistanceUnitEnum
 import com.ixam97.carStatsViewer.plot.enums.PlotDimension
 import com.ixam97.carStatsViewer.utils.Exclude
+import java.net.URL
 
 class AppPreferences(
     val context: Context
@@ -40,7 +41,7 @@ class AppPreferences(
     private val LogTargetAddress = AppPreference<String>(context.getString(R.string.preference_log_target_address_key), "ixam97@ixam97.de", sharedPref)
     private val LogUserName = AppPreference<String>(context.getString(R.string.preference_log_user_name_key), "", sharedPref)
     private val AbrpGenericToken = AppPreference<String>(context.getString(R.string.preference_abrp_generic_token_key), "", sharedPref)
-
+    private val HTTPLiveDataURL = AppPreference<String>(context.getString(R.string.preference_http_live_data_url), "", sharedPref)
 
     var versionString: String get() = VersionString.value; set(value) {VersionString.value = value}
 
@@ -63,6 +64,7 @@ class AppPreferences(
     var logUserName: String get() = LogUserName.value; set(value) {LogUserName.value = value}
     var logTargetAddress: String get() = LogTargetAddress.value; set(value) {LogTargetAddress.value = value}
     var abrpGenericToken: String get() = AbrpGenericToken.value; set(value) {AbrpGenericToken.value = value}
+    var httpLiveDataURL : String get() = HTTPLiveDataURL.value; set(value) {HTTPLiveDataURL.value = value}
 
     // Preferences not saved permanently:
     val exclusionStrategy = AppPreferences.exclusionStrategy

--- a/automotive/src/main/java/com/ixam97/carStatsViewer/dataManager/DataCollector.kt
+++ b/automotive/src/main/java/com/ixam97/carStatsViewer/dataManager/DataCollector.kt
@@ -23,6 +23,7 @@ import com.ixam97.carStatsViewer.abrpLiveData.AbrpLiveData
 import com.ixam97.carStatsViewer.activities.PermissionsActivity
 import com.ixam97.carStatsViewer.locationTracking.DefaultLocationClient
 import com.ixam97.carStatsViewer.locationTracking.LocationClient
+import com.ixam97.carStatsViewer.httpLiveData.HTTPLiveData
 import com.ixam97.carStatsViewer.plot.enums.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.Runnable
@@ -126,6 +127,9 @@ class DataCollector : Service() {
                     token = appPreferences.abrpGenericToken,
                     apiKey = abrpApiKey
                 )
+
+                val httpLiveDataURL = appPreferences.httpLiveDataURL
+                val httpLiveData = HTTPLiveData(httpLiveDataURL)
                 val dataManager = DataManagers.CURRENT_TRIP.dataManager
 
                 var lat: Double? = null
@@ -155,6 +159,15 @@ class DataCollector : Service() {
                         lon = lon,
                         alt = alt,
                         temp = dataManager.ambientTemperature
+                    )
+                ).putExtra(
+                    "status",
+                    httpLiveData.send(
+                        stateOfCharge = dataManager.stateOfCharge,
+                        power = dataManager.currentPower,
+                        speed = dataManager.currentSpeed,
+                        isCharging = dataManager.chargePortConnected,
+                        isParked = (dataManager.driveState == DrivingState.PARKED || dataManager.driveState == DrivingState.CHARGE)
                     )
                 )
 

--- a/automotive/src/main/java/httpLiveData/HTTPLiveData.kt
+++ b/automotive/src/main/java/httpLiveData/HTTPLiveData.kt
@@ -1,0 +1,58 @@
+package com.ixam97.carStatsViewer.httpLiveData
+
+import com.ixam97.carStatsViewer.InAppLogger
+import org.json.JSONObject
+import java.io.DataOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+class HTTPLiveData (val dataURL : String? = null) {
+    fun send(
+        stateOfCharge: Int,
+        power: Float,
+        isCharging: Boolean,
+        speed: Float,
+        isParked: Boolean
+    ) : Int {
+        if (dataURL == "") return 0
+
+        val url = URL(dataURL)
+
+        val con: HttpURLConnection = url.openConnection() as HttpURLConnection
+
+        con.requestMethod = "POST"
+        con.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
+        con.setRequestProperty("Accept","application/json");
+        con.doOutput = true
+        con.doInput = true
+
+        var responseCode = 0
+
+        val jsonObject = JSONObject().apply {
+                put("soc", stateOfCharge)
+                put("utc", System.currentTimeMillis() / 1000)
+                put("power", power / 1_000_000f)
+                put("is_charging", isCharging)
+                put("is_parked", isParked)
+                put("speed", speed * 3.6f)
+        }
+
+        try {
+            DataOutputStream(con.outputStream).apply {
+                writeBytes(jsonObject.toString())
+                flush()
+                close()
+            }
+            responseCode = con.responseCode
+            con.disconnect()
+        } catch (e: java.lang.Exception) {
+            InAppLogger.log("Network connection error: $e")
+            return 2
+        }
+
+        if (responseCode == 200) return 1
+
+        InAppLogger.log("HTTP connection failed. Response code: $responseCode")
+        return 2
+    }
+}

--- a/automotive/src/main/res/layout/activity_settings.xml
+++ b/automotive/src/main/res/layout/activity_settings.xml
@@ -191,6 +191,28 @@
                     <View
                         style="@style/menu_divider_style"
                         android:background="?android:attr/listDivider"/>
+                    <LinearLayout
+                        android:id="@+id/settings_http_data"
+                        android:layout_width="match_parent"
+                        android:layout_height="@dimen/std_row_height"
+                        android:orientation="horizontal">
+
+                        <ImageView
+                            android:layout_width="@dimen/row_icon_width"
+                            android:layout_height="@dimen/std_icon_size"
+                            android:layout_gravity="center"
+                            android:scaleType="fitStart"
+                            android:adjustViewBounds="true"
+                            android:src="@android:drawable/ic_popup_sync"/>
+
+                        <TextView
+                            style="@style/menu_button_row_style"
+                            android:text="Live Data URL"/>
+
+                    </LinearLayout>
+                    <View
+                        style="@style/menu_divider_style"
+                        android:background="?android:attr/listDivider"/>
 
                     <Switch
                         android:visibility="gone"

--- a/automotive/src/main/res/layout/dialog_http_data.xml
+++ b/automotive/src/main/res/layout/dialog_http_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="25dp"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/http_live_data_url"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="URL"
+        android:inputType="textUri|text"
+        android:textSize="@dimen/std_font_size" />
+</LinearLayout>

--- a/automotive/src/main/res/values/broadcast_actions.xml
+++ b/automotive/src/main/res/values/broadcast_actions.xml
@@ -8,4 +8,5 @@
     <string name="VHAL_emulator_broadcast" translatable="false">com.ixam97.carStatsViewer_dev.VHAL_emulator_broadcast</string>
     <string name="distraction_optimization_broadcast" translatable="false">com.ixam97.carStatsViewer_dev.distraction_optimization_broadcast</string>
     <string name="abrp_connection_broadcast" translatable="false">com.ixam97.carStatsViewer_dev.abrp_connection_broadcast</string>
+    <string name="http_connection_broadcast" translatable="false">com.ixam97.carStatsViewer_dev.http_connection_broadcast</string>
 </resources>

--- a/automotive/src/main/res/values/preferences_keys.xml
+++ b/automotive/src/main/res/values/preferences_keys.xml
@@ -27,4 +27,5 @@
     <string name="preference_log_user_name_key" translatable="false">preference_log_user_name</string>
     <string name="preference_version_key" translatable="false">preference_version</string>
     <string name="preference_abrp_generic_token_key" translatable="false">preference_abrp_generic_token</string>
+    <string name="preference_http_live_data_url" translatable="false">preference_http_live_data_url</string>
 </resources>


### PR DESCRIPTION
This allows the transmission of live data to a URL of the users choice.

---

For now I just played around to see what would be possible. The `HTTPLiveData` class is copied from the newly introduced `AbrpLiveData` class.

I've reused the status icon for the ABRP sync as I was somehow unable to add a new one - if I touch the main activity I am unable to start the app.

I wrote a small Prometheus Exporter which is able to retrieve the data. You can find the code here: https://github.com/jannickfahlbusch/CarStatsViewer-Exporter