### PR TITLE
Enfore HTTPS URLS

### DIFF
--- a/automotive/src/main/java/com/ixam97/carStatsViewer/liveData/http/HttpLiveData.kt
+++ b/automotive/src/main/java/com/ixam97/carStatsViewer/liveData/http/HttpLiveData.kt
@@ -55,7 +55,7 @@ class HttpLiveData (
             return false
         }
 
-        if (!possibleURL.contains("http://") && !possibleURL.contains("https://"))
+        if (!possibleURL.contains("https://"))
             return false
 
         return android.util.Patterns.WEB_URL.matcher(possibleURL).matches()

--- a/automotive/src/main/res/values-de/strings.xml
+++ b/automotive/src/main/res/values-de/strings.xml
@@ -109,7 +109,7 @@
     <string name="abrp_generic_token">Generic Token</string>
 
     <!-- HTTP -->
-    <string name="http_description">HTTP-URL und BasicAuth-Logindaten eingeben, um Live-Daten an die angegebene URL zu senden. Nutzt POST-Requests mit JSON-Inhalt. Dies beinhaltet Standortdaten, falls nicht deaktiviert.</string>
+    <string name="http_description">HTTPS-URL und BasicAuth-Logindaten eingeben, um Live-Daten an die angegebene URL zu senden. Nutzt POST-Requests mit JSON-Inhalt. Dies beinhaltet Standortdaten, falls nicht deaktiviert.</string>
     <string name="http_username">BasicAuth Nutzername</string>
     <string name="http_password">BasicAuth Passwort</string>
     <string name="http_invalid_url">Ungültige URL!</string>

--- a/automotive/src/main/res/values/strings.xml
+++ b/automotive/src/main/res/values/strings.xml
@@ -157,7 +157,7 @@
     <string name="abrp_generic_token">Generic token</string>
     
     <!-- HTTP -->
-    <string name="http_description">Enter HTTP URL and (optional) basic auth credentials to transmit live data to the specified URL. Uses POST request with JSON content. This includes location data if not disabled.</string>
+    <string name="http_description">Enter HTTPS URL and (optional) basic auth credentials to transmit live data to the specified URL. Uses POST request with JSON content. This includes location data if not disabled.</string>
     <string name="http_username">BasicAuth username</string>
     <string name="http_password">BasicAuth password</string>
     <string name="http_invalid_url">Invalid URL!</string>


### PR DESCRIPTION
Android enforces the usage of HTTPS connections since 2018. To support unencrpyted HTTP webhooks we would need to allow HTTP traffic for all communication within the app. Menawhile every user should be able to request Let's Encrypt certificates for their domains.